### PR TITLE
Enhance waveguide PCell: tech lookup & pins 

### DIFF
--- a/waveguide_pcell.py
+++ b/waveguide_pcell.py
@@ -7,33 +7,76 @@ import SiEPIC
 from SiEPIC.utils import get_technology_by_name
 
 class WaveguidePCell(pya.PCellDeclarationHelper):
+    """
+    Straight Waveguide PCell for SiEPIC EBeam PDK
+    Author: Subhash Arya (updated with fixes)
+    """
     def __init__(self):
         super().__init__()
         self.param("width", self.TypeDouble, "Waveguide Width (um)", default=0.5)
         self.param("length", self.TypeDouble, "Waveguide Length (um)", default=10.0)
 
-    def display_text_impl(self):
-        return f"Waveguide (width={self.width}, length={self.length})"
-
     def produce_impl(self):
-        tech = get_technology_by_name("EBeam")
-        dbu = self.layout.dbu
-        width = self.width 
-        length = self.length
-        points = [
-            pya.DPoint(0, -width/2),
-            pya.DPoint(length, -width/2),
-            pya.DPoint(length, width/2),
-            pya.DPoint(0, width/2)
-        ]
-        shape = pya.DPolygon(points)
-        self.cell.shapes(self.layout.layer(tech["Si"])).insert(shape)
+        # Get EBeam technology layers
+        try:
+            tech = get_technology_by_name("EBeam")
+        except:
+            # Fallback layer indices (adjust if your technology uses different numbers)
+            tech = {
+                "Si": self.layout.layer(1, 0),
+                "DevRec": self.layout.layer(68, 0),
+                "PinRec": self.layout.layer(69, 0)
+            }
 
-# Register the PCell
+        width = self.width
+        length = self.length
+
+        # === Silicon Waveguide Core ===
+        points = [
+            pya.DPoint(0, -width / 2.0),
+            pya.DPoint(length, -width / 2.0),
+            pya.DPoint(length, width / 2.0),
+            pya.DPoint(0, width / 2.0)
+        ]
+        wg_poly = pya.DPolygon(points)
+        self.cell.shapes(tech["Si"]).insert(wg_poly)
+
+        # === Device Recognition (DevRec) ===
+        devrec_box = pya.DBox(0, -width / 2.0, length, width / 2.0)
+        self.cell.shapes(tech["DevRec"]).insert(devrec_box)
+
+        # === Pin Recognition (PinRec) ===
+        pinrec = tech["PinRec"]
+        pin_len = 0.2   # µm (standard in SiEPIC)
+        half_pin = pin_len / 2.0
+
+        # Left Pin
+        self.cell.shapes(pinrec).insert(pya.DBox(-half_pin, -width/2.0, half_pin, width/2.0))
+        # Right Pin
+        self.cell.shapes(pinrec).insert(pya.DBox(length - half_pin, -width/2.0, length + half_pin, width/2.0))
+
+        # === Pin Labels (Critical for SiEPIC netlisting) ===
+        text_size = 0.4  # µm
+
+        # Left pin text
+        t1 = pya.DText("pin1", pya.DPoint(0, 0), text_size)
+        t1.halign = pya.DText.HAlignCenter
+        t1.valign = pya.DText.VAlignCenter
+        self.cell.shapes(pinrec).insert(t1)
+
+        # Right pin text
+        t2 = pya.DText("pin2", pya.DPoint(length, 0), text_size)
+        t2.halign = pya.DText.HAlignCenter
+        t2.valign = pya.DText.VAlignCenter
+        self.cell.shapes(pinrec).insert(t2)
+
+
+# ==================== Library Registration ====================
 class WaveguideLibrary(pya.Library):
     def __init__(self):
-        self.description = "Waveguide PCell Library"
+        self.description = "Custom Straight Waveguide PCell for SiEPIC EBeam"
         self.layout().register_pcell("Waveguide", WaveguidePCell())
         self.register("WaveguideLibrary")
 
+# Create the library when macro is run
 WaveguideLibrary()


### PR DESCRIPTION
Improve the straight waveguide PCell for the SiEPIC EBeam PDK: add a docstring and more robust technology layer lookup with a fallback, create the silicon waveguide polygon, and insert Device Recognition (DevRec) and Pin Recognition (PinRec) shapes. Add left/right pin boxes and centered pin text labels (for SiEPIC netlisting) and set standard pin length and text size. Remove the old display_text_impl and update the library description. These changes make the PCell more interoperable with varying tech setups and ensure proper netlisting metadata.